### PR TITLE
Dbet 855 ui to explain to the user why they need min 7500 vtho

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "decent-bet-frontend",
-    "version": "1.0.29-develop",
+    "version": "1.0.30-develop",
     "homepage": "https://decent.bet",
     "private": true,
     "devDependencies": {


### PR DESCRIPTION
 for add updated version tag to 1.0.30-develop